### PR TITLE
Fix CI: support Laravel 12/13, drop EOL Laravel 10, add Codecov

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,9 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: true
       matrix:
@@ -23,13 +26,13 @@ jobs:
         include:
           - laravel: 11.*
             testbench: ^9.9
-            carbon: ^2.72.2
+            carbon: ^2.72.6
           - laravel: 12.*
             testbench: 10.*
-            carbon: ^3.0
+            carbon: ^3.8.4
           - laravel: 13.*
             testbench: 11.*
-            carbon: ^3.0
+            carbon: ^3.8.4
         exclude:
           - laravel: 13.*
             php: 8.2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,24 +18,21 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3, 8.2]
-        laravel: [13.*, 12.*, 11.*, 10.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-            carbon: ^2.63
           - laravel: 11.*
-            testbench: 9.*
+            testbench: ^9.9
             carbon: ^2.72.2
           - laravel: 12.*
             testbench: 10.*
             carbon: ^3.0
           - laravel: 13.*
-            testbench: 10.*
+            testbench: 11.*
             carbon: ^3.0
         exclude:
-          - laravel: 10.*
-            php: 8.4
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -64,4 +61,31 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci
+        run: vendor/bin/pest --ci --no-coverage
+
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    name: Coverage
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          coverage: pcov
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction
+
+      - name: Execute tests with coverage
+        run: vendor/bin/pest --ci --coverage-clover build/logs/clover.xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -17,22 +17,22 @@
     ],
     "require": {
         "php": "^8.2|^8.3|^8.4",
-        "illuminate/contracts": "^10.0 || ^11.0 || ^12.0 || ^13.0",
+        "illuminate/contracts": "^11.0 || ^12.0 || ^13.0",
         "league/iso3166": "^4.3",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
-        "larastan/larastan": "^2.0.1",
+        "larastan/larastan": "^2.0.1 || ^3.0",
         "laravel/boost": "^2.4",
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^8.5",
-        "orchestra/testbench": "^10.0|^9.0|^8.8",
-        "pestphp/pest": "^2.20",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "pestphp/pest": "^2.36 || ^3.0 || ^4.0",
+        "pestphp/pest-plugin-arch": "^2.0 || ^3.0 || ^4.0",
+        "pestphp/pest-plugin-laravel": "^2.0 || ^3.0 || ^4.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
+        "phpstan/phpstan-phpunit": "^1.0 || ^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -60,7 +60,7 @@
             "@php vendor/bin/testbench serve"
         ],
         "analyse": "vendor/bin/phpstan analyse",
-        "test": "vendor/bin/pest",
+        "test": "vendor/bin/pest --no-coverage",
         "test-coverage": "vendor/bin/pest --coverage",
         "format": "vendor/bin/pint"
     },


### PR DESCRIPTION
## Why

The `run-tests` workflow is red. The matrix added Laravel 12 & 13, but the dev dependencies were pinned to majors that don't support them, so `composer update` failed at the **Install dependencies** step — before tests ever ran. The 7 tests themselves pass.

## Root causes found

1. **Pest stack too old** — `pest ^2.20` / `pest-plugin-laravel ^2.0` / `pest-plugin-arch ^2.0` only support Laravel ≤11. CI doesn't override Pest, so L12/L13 couldn't resolve (the exact error in the logs).
2. **larastan + phpstan extensions too old** — `larastan ^2.0.1` caps at Laravel 11 and forces `phpstan ^1`. Blocked L12/L13.
3. **Wrong testbench for L13** — matrix pinned L13 → `testbench 10.*` (that's L12); L13 needs `11.*`. L13 was also tested on PHP 8.2, but Laravel 13 requires PHP ≥8.3.
4. **Pest 4 aborts without a coverage driver** — `phpunit.xml.dist` configures `<coverage>` reports; under Pest 4 a missing driver is a *fatal* abort (Pest 2 only warned), and CI runs `coverage: none`.
5. **testbench-core 9.0.x `$latestResponse` skew** — prefer-lowest L11 paired the oldest testbench-core (9.0.0, which resets `$latestResponse`) with a newer Laravel 11 that removed it (`boost ^2.4` forces laravel ≥11.45).

## Changes

**composer.json**
- `pest` / `pest-plugin-*` → `^2.36 || ^3.0 || ^4.0`
- `larastan` → `^2.0.1 || ^3.0`; phpstan extensions → `^1.0 || ^2.0`
- drop EOL Laravel 10: `illuminate ^11|^12|^13`, `testbench ^9|^10|^11` (`collision ^8.5` and `boost ^2.4` no longer support L10)
- `test` script → `--no-coverage`

**.github/workflows/run-tests.yml**
- remove Laravel 10 from the matrix
- L13 → `testbench 11.*`; exclude L13 + PHP 8.2
- L11 → `testbench ^9.9`
- `--no-coverage` on the matrix test command
- new **Coverage** job (pcov) that uploads to Codecov (needs a `CODECOV_TOKEN` repo secret)

> **Note:** Laravel 10 was dropped (EOL since Feb 2025) because `collision ^8.5` requires Laravel ≥11.48 and `boost ^2.4` requires illuminate ≥11.45 — its support was already broken by recent dependabot bumps.

## Verification

Simulated every remaining matrix cell on PHP 8.4, both stabilities — all green:

| Cell | prefer-lowest | prefer-stable |
|------|---------------|---------------|
| L11 | ✅ Pest 2.36 | ✅ Pest 4 |
| L12 | ✅ Pest 3 | ✅ Pest 4 |
| L13 | ✅ Pest 4.4 | ✅ Pest 4.7 |

`composer test` and `composer analyse` (phpstan level 9, now larastan 3 + phpstan 2) both pass.