### PR TITLE
Add Codecov coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/baspa/laravel-timezones.svg?style=flat-square)](https://packagist.org/packages/baspa/laravel-timezones)
 [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/baspa/laravel-timezones/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/baspa/laravel-timezones/actions?query=workflow%3Arun-tests+branch%3Amain)
+[![Code Coverage](https://img.shields.io/codecov/c/github/baspa/laravel-timezones?style=flat-square)](https://codecov.io/gh/baspa/laravel-timezones)
 [![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/baspa/laravel-timezones/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/baspa/laravel-timezones/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/baspa/laravel-timezones.svg?style=flat-square)](https://packagist.org/packages/baspa/laravel-timezones)
 


### PR DESCRIPTION
Adds a Codecov coverage badge alongside the existing badges, matching the `flat-square` style. Pairs with the Coverage job added in #24.

```
[![Code Coverage](https://img.shields.io/codecov/c/github/baspa/laravel-timezones?style=flat-square)](https://codecov.io/gh/baspa/laravel-timezones)
```